### PR TITLE
Updated cert revoke to renew the cert automatically to fix #24

### DIFF
--- a/renew_cert.sh
+++ b/renew_cert.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Look up the serial number of the cert to revoke on the cert itself on the webserver
+# By default it should be 1000
+
+if [ $# = 0 ]
+then
+  cert=1000
+else
+  cert=$1
+fi
+
+cp data/ssl/certs/bitwarden.crt data/ssl/certs/bitwarden.crt.bak
+openssl ca -revoke data/ssl/newcerts/$cert.pem -config data/ssl/bitwarden.ext
+openssl ca -config data/ssl/bitwarden.ext -extensions server_cert -days 365 -notext -md sha256 -in data/ssl/csr/bitwarden.csr -out data/ssl/certs/bitwarden.crt

--- a/revoke_cert.sh
+++ b/revoke_cert.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# Look up the serial number of the cert to revoke on the cert itself on the webserver
-# By default it should be 1000
-
-openssl ca -revoke data/ssl/newcerts/$1.pem -config data/ssl/bitwarden.ext


### PR DESCRIPTION
Moved the current revoke to backup and renew the cert automatically. This will work for the first renewal when the cert serial number=1000, but afterward the new cert serial (1001, 1002, etc) will need to be added as a command line argument. 